### PR TITLE
Update SQLAlchemy version in requirements.txt to 1.3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ blinker>=1.4
 Flask>=0.12
 Flask-SQLAlchemy>=2
 pbr==3.1.1
-SQLAlchemy==1.1.13
+SQLAlchemy==1.3.12
 Whoosh==2.7.4


### PR DESCRIPTION
As addressed in the issues I opened #3 and #5 the requirement.txt SQLAlchemy version of 1.1.3 has some vulnerabilities and is incompatible with Python 3.8+.

Upgrading SQLALchemy to 1.3.12 after installing Flask-WhooshAlchemy3 looks to have broken nothing. Indexes are created and search functionality continues to work.

Let me know if there is anything else you'd like to me do in order to get this approved.